### PR TITLE
fix(async_hooks): support remove related async hooks

### DIFF
--- a/src/wrappers/express.js
+++ b/src/wrappers/express.js
@@ -94,9 +94,8 @@ function nextWrapper(next) {
             utils.debugLog(error);
         }
 
-        traceContext.setAsyncReference(asyncId, true);
         const result = originalNext(...arguments);
-        traceContext.setAsyncReference(asyncId, true);
+        traceContext.setAsyncReference(asyncId);
         return result;
     };
 }


### PR DESCRIPTION
Question
Do we need to add "traceContext.destroyAsync(asyncHooks.executionAsyncId(), true);"
after any sendTrace call in epsagon-frameworks?