### PR TITLE
fix(async_hooks): properly remove old tracers

### DIFF
--- a/examples/express_example.js
+++ b/examples/express_example.js
@@ -14,7 +14,8 @@ app.get('/', (req, res) => res.send('Hello World!'))
 app.get('/label_example', (req, res) => {
     // Example label usage
     req.epsagon.label('myFirstLabel', 'customValue1');
-    res.send('Hello World!'))
-}
+    res.send('Hello World!')
+})
+
 
 app.listen(3000)

--- a/src/trace_context.js
+++ b/src/trace_context.js
@@ -18,8 +18,9 @@ const weaks = new WeakMap();
  */
 function destroyAsync(asyncId, forceDelete = false) {
     if (forceDelete) {
+        const asyncTrace = tracers[asyncId];
         Object.entries(tracers).forEach(([key, tracer]) => {
-            if (tracers[asyncId] === tracer) {
+            if (asyncTrace === tracer) {
                 delete tracers[key];
             }
         });


### PR DESCRIPTION
- Tracers object is now properly handled
- Tested with requests rate of 400/s on express server:
   - Tracers map memory leak solved
   - CPU usage reduced by 50% 
