### PR TITLE
add `ignoreEndpoints` to ts typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,4 +36,5 @@ declare module 'epsagon' {
   export function wrapBatchJob(): void
   export function enable(): void
   export function disable(): void
+  export function ignoreEndpoints(endpoints: string[]):void
 }


### PR DESCRIPTION
it's exported in index.js
https://github.com/epsagon/epsagon-node-frameworks/blob/master/src/index.js#L14